### PR TITLE
Migrate Next.js to Rust WinUI3

### DIFF
--- a/aviutl2-style-config-editor-winui/Cargo.toml
+++ b/aviutl2-style-config-editor-winui/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_UI_Controls", "Win32_Globalization"] }
+windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_UI_Controls", "Win32_Globalization", "UI_Xaml"] }
+quick-xml = "0.31"
+anyhow = "1.0"
+once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/aviutl2-style-config-editor-winui/Cargo.toml
+++ b/aviutl2-style-config-editor-winui/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "aviutl2_style_config_editor_winui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_UI_Controls", "Win32_Globalization"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/aviutl2-style-config-editor-winui/README.md
+++ b/aviutl2-style-config-editor-winui/README.md
@@ -1,0 +1,15 @@
+# aviutl2-style-config-editor-winui
+
+Rust + WinUI 3 で作成された AviUtl スタイル設定エディタ
+
+## ビルド方法
+
+1. Rust toolchain をインストール
+2. Windows App SDK/WinUI 3 のセットアップ
+3. `cargo build`
+
+## 構成
+- main_window: メイン画面
+- components/language_switcher: 言語切替
+- components/settings_card: 設定カード
+- i18n: 多言語リソース

--- a/aviutl2-style-config-editor-winui/src/app.xaml
+++ b/aviutl2-style-config-editor-winui/src/app.xaml
@@ -1,0 +1,8 @@
+<Application
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="App">
+    <Application.Resources>
+        <!-- グローバルリソース -->
+    </Application.Resources>
+</Application>

--- a/aviutl2-style-config-editor-winui/src/components/language_switcher.rs
+++ b/aviutl2-style-config-editor-winui/src/components/language_switcher.rs
@@ -1,0 +1,12 @@
+pub struct LanguageSwitcher {
+    pub current_lang: String,
+}
+
+impl LanguageSwitcher {
+    pub fn new() -> Self {
+        Self { current_lang: "ja".to_string() }
+    }
+    pub fn set_language(&mut self, lang: &str) {
+        self.current_lang = lang.to_string();
+    }
+}

--- a/aviutl2-style-config-editor-winui/src/components/language_switcher.rs
+++ b/aviutl2-style-config-editor-winui/src/components/language_switcher.rs
@@ -8,5 +8,9 @@ impl LanguageSwitcher {
     }
     pub fn set_language(&mut self, lang: &str) {
         self.current_lang = lang.to_string();
+        // TODO: UI更新やリソース再読込処理
+    }
+    pub fn get_language(&self) -> &str {
+        &self.current_lang
     }
 }

--- a/aviutl2-style-config-editor-winui/src/components/language_switcher.xaml
+++ b/aviutl2-style-config-editor-winui/src/components/language_switcher.xaml
@@ -1,0 +1,9 @@
+<UserControl
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="LanguageSwitcher">
+    <ComboBox x:Name="LanguageComboBox" Width="120">
+        <ComboBoxItem Content="日本語" Tag="ja" />
+        <ComboBoxItem Content="English" Tag="en" />
+    </ComboBox>
+</UserControl>

--- a/aviutl2-style-config-editor-winui/src/components/language_switcher.xaml
+++ b/aviutl2-style-config-editor-winui/src/components/language_switcher.xaml
@@ -2,8 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:Class="LanguageSwitcher">
-    <ComboBox x:Name="LanguageComboBox" Width="120">
-        <ComboBoxItem Content="日本語" Tag="ja" />
-        <ComboBoxItem Content="English" Tag="en" />
-    </ComboBox>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="8">
+        <Button x:Name="BtnJa" Content="日本語" Width="80" Margin="0,0,8,0" />
+        <Button x:Name="BtnEn" Content="English" Width="80" />
+    </StackPanel>
 </UserControl>

--- a/aviutl2-style-config-editor-winui/src/components/settings_card.rs
+++ b/aviutl2-style-config-editor-winui/src/components/settings_card.rs
@@ -1,10 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum SettingType {
+    Text,
+    Number,
+    Color,
+    Info,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SettingItem {
+    pub label: String,
+    pub label_key: Option<String>,
+    pub internal_group: String,
+    pub internal_id: String,
+    pub setting_type: SettingType,
+    pub placeholder: Option<String>,
+    pub value: Option<String>,
+    pub is_selected: bool,
+}
+
 pub struct SettingsCard {
-    // 設定項目の状態など
+    pub title: String,
+    pub items: Vec<SettingItem>,
 }
 
 impl SettingsCard {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(title: &str, items: Vec<SettingItem>) -> Self {
+        Self {
+            title: title.to_string(),
+            items,
+        }
     }
-    // 設定操作用のメソッドをここに追加
+    pub fn on_item_change(&mut self, group: &str, id: &str, value: &str) {
+        for item in &mut self.items {
+            if item.internal_group == group && item.internal_id == id {
+                item.value = Some(value.to_string());
+            }
+        }
+    }
+    pub fn on_item_select(&mut self, group: &str, id: &str, selected: bool) {
+        for item in &mut self.items {
+            if item.internal_group == group && item.internal_id == id {
+                item.is_selected = selected;
+            }
+        }
+    }
+    pub fn get_label(&self, key: &str, t: &dyn Fn(&str) -> String) -> String {
+        t(key)
+    }
 }

--- a/aviutl2-style-config-editor-winui/src/components/settings_card.rs
+++ b/aviutl2-style-config-editor-winui/src/components/settings_card.rs
@@ -1,0 +1,10 @@
+pub struct SettingsCard {
+    // 設定項目の状態など
+}
+
+impl SettingsCard {
+    pub fn new() -> Self {
+        Self {}
+    }
+    // 設定操作用のメソッドをここに追加
+}

--- a/aviutl2-style-config-editor-winui/src/components/settings_card.xaml
+++ b/aviutl2-style-config-editor-winui/src/components/settings_card.xaml
@@ -6,7 +6,16 @@
         <StackPanel>
             <TextBlock x:Name="TitleText" FontWeight="Bold" FontSize="16" Margin="0,0,0,8" />
             <ItemsControl x:Name="SettingsList">
-                <!-- 各設定項目はDataTemplateでバインド -->
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Margin="0,4">
+                            <CheckBox IsChecked="{Binding is_selected}" Margin="0,0,8,0" />
+                            <TextBlock Text="{Binding label}" Width="120" Margin="0,0,8,0" />
+                            <TextBox Text="{Binding value}" Width="120" Visibility="{Binding setting_type, Converter={StaticResource TextTypeVisibilityConverter}}" />
+                            <!-- ColorPickerや他の型もここで分岐可能 -->
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
             </ItemsControl>
         </StackPanel>
     </Border>

--- a/aviutl2-style-config-editor-winui/src/components/settings_card.xaml
+++ b/aviutl2-style-config-editor-winui/src/components/settings_card.xaml
@@ -1,0 +1,11 @@
+<UserControl
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="SettingsCard">
+    <Border BorderBrush="Gray" BorderThickness="1" Padding="12" Margin="8">
+        <StackPanel>
+            <TextBlock Text="設定" FontWeight="Bold" FontSize="16" />
+            <!-- 設定項目をここに追加 -->
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/aviutl2-style-config-editor-winui/src/components/settings_card.xaml
+++ b/aviutl2-style-config-editor-winui/src/components/settings_card.xaml
@@ -4,8 +4,10 @@
     x:Class="SettingsCard">
     <Border BorderBrush="Gray" BorderThickness="1" Padding="12" Margin="8">
         <StackPanel>
-            <TextBlock Text="設定" FontWeight="Bold" FontSize="16" />
-            <!-- 設定項目をここに追加 -->
+            <TextBlock x:Name="TitleText" FontWeight="Bold" FontSize="16" Margin="0,0,0,8" />
+            <ItemsControl x:Name="SettingsList">
+                <!-- 各設定項目はDataTemplateでバインド -->
+            </ItemsControl>
         </StackPanel>
     </Border>
 </UserControl>

--- a/aviutl2-style-config-editor-winui/src/i18n/en.resw
+++ b/aviutl2-style-config-editor-winui/src/i18n/en.resw
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Language</value>
+  </data>
+</root>

--- a/aviutl2-style-config-editor-winui/src/i18n/en.resw
+++ b/aviutl2-style-config-editor-winui/src/i18n/en.resw
@@ -6,4 +6,22 @@
   <data name="Language" xml:space="preserve">
     <value>Language</value>
   </data>
+  <data name="Japanese" xml:space="preserve">
+    <value>Japanese</value>
+  </data>
+  <data name="English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="FontSettings" xml:space="preserve">
+    <value>Font Settings</value>
+  </data>
+  <data name="ColorSettings" xml:space="preserve">
+    <value>Color Settings</value>
+  </data>
+  <data name="LayoutSettings" xml:space="preserve">
+    <value>Layout Settings</value>
+  </data>
+  <data name="FormatSettings" xml:space="preserve">
+    <value>Format Settings</value>
+  </data>
 </root>

--- a/aviutl2-style-config-editor-winui/src/i18n/ja.resw
+++ b/aviutl2-style-config-editor-winui/src/i18n/ja.resw
@@ -6,4 +6,22 @@
   <data name="Language" xml:space="preserve">
     <value>言語</value>
   </data>
+  <data name="Japanese" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="FontSettings" xml:space="preserve">
+    <value>フォントの設定</value>
+  </data>
+  <data name="ColorSettings" xml:space="preserve">
+    <value>色の設定</value>
+  </data>
+  <data name="LayoutSettings" xml:space="preserve">
+    <value>レイアウトの設定</value>
+  </data>
+  <data name="FormatSettings" xml:space="preserve">
+    <value>形式の設定</value>
+  </data>
 </root>

--- a/aviutl2-style-config-editor-winui/src/i18n/ja.resw
+++ b/aviutl2-style-config-editor-winui/src/i18n/ja.resw
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Settings" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>言語</value>
+  </data>
+</root>

--- a/aviutl2-style-config-editor-winui/src/main.rs
+++ b/aviutl2-style-config-editor-winui/src/main.rs
@@ -1,0 +1,5 @@
+mod main_window;
+
+fn main() -> windows::Result<()> {
+    main_window::run()
+}

--- a/aviutl2-style-config-editor-winui/src/main_window.rs
+++ b/aviutl2-style-config-editor-winui/src/main_window.rs
@@ -1,0 +1,7 @@
+use windows::Win32::Foundation::*;
+
+pub fn run() -> windows::Result<()> {
+    // ここでWinUI 3のWindowを生成し、XAMLをロードする処理を記述
+    println!("WinUI 3 Main Window 起動");
+    Ok(())
+}

--- a/aviutl2-style-config-editor-winui/src/main_window.rs
+++ b/aviutl2-style-config-editor-winui/src/main_window.rs
@@ -1,7 +1,71 @@
 use windows::Win32::Foundation::*;
+use crate::components::language_switcher::LanguageSwitcher;
+use crate::components::settings_card::{SettingsCard, SettingItem, SettingType};
+use std::collections::HashMap;
+
+pub struct AppState {
+    pub language: String,
+    pub settings: Vec<SettingItem>,
+    pub translations: HashMap<String, HashMap<String, String>>, // lang -> key -> value
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        let mut translations = HashMap::new();
+        translations.insert("ja".to_string(), load_resw("src/i18n/ja.resw"));
+        translations.insert("en".to_string(), load_resw("src/i18n/en.resw"));
+        Self {
+            language: "ja".to_string(),
+            settings: vec![
+                SettingItem {
+                    label: "Font Settings".to_string(),
+                    label_key: Some("FontSettings".to_string()),
+                    internal_group: "font".to_string(),
+                    internal_id: "defaultFont".to_string(),
+                    setting_type: SettingType::Text,
+                    placeholder: Some("MS UI Gothic".to_string()),
+                    value: Some("".to_string()),
+                    is_selected: false,
+                },
+                SettingItem {
+                    label: "Color Settings".to_string(),
+                    label_key: Some("ColorSettings".to_string()),
+                    internal_group: "color".to_string(),
+                    internal_id: "backgroundColor".to_string(),
+                    setting_type: SettingType::Color,
+                    placeholder: None,
+                    value: Some("#ffffff".to_string()),
+                    is_selected: true,
+                },
+            ],
+            translations,
+        }
+    }
+    pub fn t(&self, key: &str) -> String {
+        self.translations
+            .get(&self.language)
+            .and_then(|map| map.get(key))
+            .cloned()
+            .unwrap_or_else(|| key.to_string())
+    }
+    pub fn set_language(&mut self, lang: &str) {
+        self.language = lang.to_string();
+    }
+}
+
+fn load_resw(path: &str) -> HashMap<String, String> {
+    // 本来はXMLパースするが、ここでは簡易的に空で返す
+    HashMap::new()
+}
 
 pub fn run() -> windows::Result<()> {
-    // ここでWinUI 3のWindowを生成し、XAMLをロードする処理を記述
-    println!("WinUI 3 Main Window 起動");
+    let mut app_state = AppState::new();
+    let mut lang_switcher = LanguageSwitcher::new();
+    let mut settings_card = SettingsCard::new(
+        &app_state.t("Settings"),
+        app_state.settings.clone(),
+    );
+    // TODO: WinUI 3ウィンドウ生成・XAMLバインド・イベント連携
+    println!("[{}] {}", app_state.language, app_state.t("Settings"));
     Ok(())
 }

--- a/aviutl2-style-config-editor-winui/src/main_window.xaml
+++ b/aviutl2-style-config-editor-winui/src/main_window.xaml
@@ -6,7 +6,7 @@
     Title="AviUtl2 Style Config Editor"
     Height="400" Width="600">
     <StackPanel>
-        <local:LanguageSwitcher />
-        <local:SettingsCard />
+        <local:LanguageSwitcher x:Name="LangSwitcher" />
+        <local:SettingsCard x:Name="SettingsCard" />
     </StackPanel>
 </Window>

--- a/aviutl2-style-config-editor-winui/src/main_window.xaml
+++ b/aviutl2-style-config-editor-winui/src/main_window.xaml
@@ -1,0 +1,12 @@
+<Window
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:components"
+    x:Class="MainWindow"
+    Title="AviUtl2 Style Config Editor"
+    Height="400" Width="600">
+    <StackPanel>
+        <local:LanguageSwitcher />
+        <local:SettingsCard />
+    </StackPanel>
+</Window>


### PR DESCRIPTION
Port `aviutl2-style-config-editor` from Next.js to Rust + WinUI 3, creating the initial project structure and boilerplate.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a381c14-8e15-4373-b7a0-21f5c875f872">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a381c14-8e15-4373-b7a0-21f5c875f872">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

